### PR TITLE
Propagate outputs from create-pr step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
 
   test-github-action:
     runs-on: ubuntu-latest
+    outputs:
+      pr_branch: ${{ steps.update.outputs.pull-request-branch }}
 
     steps:
     - name: Checkout the head commit of the branch
@@ -41,3 +43,21 @@ jobs:
             exit 1
           fi
       shell: bash
+
+  cleanup-tests:
+    needs: [test-github-action]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the PR commit of the branch
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+        ref: ${{ needs.test-github-action.outputs.pr_branch }}
+
+    - name: Revert changes and close PR
+      uses: bennettoxford/update-dependencies-action@v1
+      with:
+        update_command: "rm update.txt && rm on_changes.txt"
+        pr_title: "PR from test run on ${{ github.ref_name }}"
+        automerge: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,20 @@ jobs:
       with:
         persist-credentials: false
                        
-    - name: Test 
+    - name: Test
+      id: update
       uses: bennettoxford/update-dependencies-action@v1
       with: 
         update_command: "echo updated > update.txt"
         on_changes_command: "echo changed > on_changes.txt"
         pr_title: "PR from test run on ${{ github.ref_name }}"
         automerge: false
-  
+
+    - name: Check PR created output
+      run: |
+          set +e
+          if [ "${{ steps.update.outputs.pull-request-operation }}" != "created" ]; then
+            echo "::error::Expected PR operation created, found ${{ steps.update.outputs.pull-request-operation }}"
+            exit 1
+          fi
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -94,6 +94,34 @@ repository permissions:
 
 See the `create-pull-request` [docs][2] for other options.
 
+## Action outputs
+Outputs from the `create-pull-request` action are propograted and can be used by subsequent workflow steps.
+
+- `pull-request-number` - The pull request number.
+- `pull-request-url` - The URL of the pull request.
+- `pull-request-operation` - The pull request operation performed by the action, created, updated, or none.
+- `pull-request-head-sha` - The commit SHA of the pull request branch.
+- `pull-request-branch` - The branch name of the pull request.
+
+For example, to post a created or update PR to a slack channel:
+
+```
+  ...
+    - uses: bennettoxford/update-dependencies-action@v1
+      id: update_dependencies
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
+
+    - name: Notify slack
+      if: ${{ steps.update_dependencies.outputs.pull-request-operation != 'none' }}
+      uses: slackapi/slack-github-action@v2.0.0
+      with:
+        method: chat.postMessage
+        token: << SLACK_BOT_TOKEN >>
+        payload: |
+          channel: "channel-id"
+          text: "Update dependencies\n${{ steps.update_dependencies.outputs.pull-request-url }}"
+```
 
 ## Releasing a new version
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,22 @@ inputs:
     description: "Enable automerge on PRs created by the action"
     default: true
 
+outputs:
+  pull-request-number:
+    description: 'The pull request number'
+    value: ${{ steps.create_pr.outputs.pull-request-number }}
+  pull-request-url:
+    description: 'The URL of the pull request.'
+    value: ${{ steps.create_pr.outputs.pull-request-url }}
+  pull-request-operation:
+    description: 'The pull request operation performed by the action, `created` or `updated`.'
+    value: ${{ steps.create_pr.outputs.pull-request-operation }}
+  pull-request-head-sha:
+    description: 'The commit SHA of the pull request branch.'
+    value: ${{ steps.create_pr.outputs.pull-request-head-sha }}
+  pull-request-branch:
+    description: 'The pull request branch name'
+    value: ${{ steps.create_pr.outputs.pull-request-branch }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
Propagate PR-related outputs so we can use them in further actions (e.g. to post links to slack).

Also fixes #8 