### PR TITLE
Sign commits by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For example, to post a created or update PR to a slack channel:
 
     - name: Notify slack
       if: ${{ steps.update_dependencies.outputs.pull-request-operation != 'none' }}
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@<sha>
       with:
         method: chat.postMessage
         token: << SLACK_BOT_TOKEN >>

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ jobs:
 | commit_message | Commit message if changes found| no | "chore: update-dependencies" |
 | pr_title | Pull request title | no | "Update dependencies" |
 | automerge | Enable automerge on PRs created with the action | no | true |
+| sign-commits | Sign commits as `github-actions[bot]` when using `GITHUB_TOKEN`, or your own bot when using GitHub App tokens. | no | true |
 
 
 ## Workflows triggered by pull requests

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "Enable automerge on PRs created by the action"
     default: true
 
+  sign-commits:
+    description: 'Sign commits as `github-actions[bot]` when using `GITHUB_TOKEN`, or your own bot when using GitHub App tokens.'
+    default: true
+
 outputs:
   pull-request-number:
     description: 'The pull request number'
@@ -72,6 +76,7 @@ runs:
         title: ${{ inputs.pr_title }}
         body: Automated changes by [update-dependencies-action](https://github.com/bennettoxford/update-dependencies-action)
         token: ${{ inputs.token }}
+        sign-commits: ${{ inputs.sign-commits }}
 
     # The PR will still need to pass any required checks, this just reduces it to a one-click process
     - name: Enable automerge


### PR DESCRIPTION
Add an optional input to sign commits created by this action. Defaults to true, because it shouldn't break anything on repos that don't require commit-signing, and will do the right thing for any that do require it.

Plus drive-by fix to the README slack example.

Fixes #32 