### PR TITLE
Add cooldown period to default command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ inputs:
   update_command: 
     description: "A command to update all dependencies"
     required: false
-    default: "just update-dependencies"
+    default: "just update-dependencies '7 days ago'"
   
   on_changes_command: 
     description: "A command to run after dependencies have been updated"


### PR DESCRIPTION
As per our Dependency Updates Policy, any Python dependency that is less than 7 days old should not be proposed for update by this action. Hence, the default command now includes a cooldown period of 7 days; the syntax assumes that the command runner is a Linux system with GNU date.

Repos can still override this default by specifying their own command with the `update_command` input.

Note that this is a breaking change for any repos that use `pip` to manage Python dependencies as the `pip` implementation of the `just update-dependencies` command does not support arguments. Hence, this commit should not be included in version 1 of the action, and version 2 should be released instead.

Repos should switch to using `uv` to manage Python dependencies and version 2 of the action to implement the cooldown period for automated updates.